### PR TITLE
Fix Timecast Filtering Logic

### DIFF
--- a/src/main/java/club/dnd5/portal/controller/api/bestiary/BestiaryApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/bestiary/BestiaryApiController.java
@@ -53,11 +53,11 @@ public class BestiaryApiController {
 	@PostMapping(value = "/api/v1/bestiary", produces = MediaType.APPLICATION_JSON_VALUE)
 	public List<BeastApi> getBestiary(@RequestBody BeastlRequesApi request) {
 		Specification<Creature> specification = null;
-		Optional<BeastlRequesApi> optionalRequest = Optional.of(request);
+		Optional<BeastlRequesApi> optionalRequest = Optional.ofNullable(request);
 		if (!optionalRequest.map(RequestApi::getSearch).map(SearchRequest::getValue).orElse("").isEmpty()) {
 			specification = SpecificationUtil.getSearch(request);
 		}
-		Optional<BeastFilter> filter = Optional.of(request.getFilter());
+		Optional<BeastFilter> filter = Optional.ofNullable(request.getFilter());
 		if (optionalRequest.map(BeastlRequesApi::getFilter).map(BeastFilter::getNpc).orElseGet(Collections::emptyList).isEmpty()) {
 			specification = SpecificationUtil.getAndSpecification(specification,
 				(root, query, cb) -> cb.notEqual(root.get("raceId"), 102));

--- a/src/main/java/club/dnd5/portal/util/SpecificationUtil.java
+++ b/src/main/java/club/dnd5/portal/util/SpecificationUtil.java
@@ -5,6 +5,7 @@ import club.dnd5.portal.dto.api.spells.SearchRequest;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -50,12 +51,9 @@ public final class SpecificationUtil {
 	public static <T> Specification<T> combineWithOr(List<Specification<T>> specifications) {
 		Specification<T> combinedSpecification = null;
 		for (Specification<T> specification : specifications) {
-			if (combinedSpecification == null) {
-				combinedSpecification = specification;
-			} else {
-				combinedSpecification = combinedSpecification.or(specification);
-			}
+			combinedSpecification = (Objects.isNull(combinedSpecification)) ? specification : combinedSpecification.or(specification);
 		}
 		return combinedSpecification;
 	}
+
 }

--- a/src/main/java/club/dnd5/portal/util/SpecificationUtil.java
+++ b/src/main/java/club/dnd5/portal/util/SpecificationUtil.java
@@ -4,6 +4,7 @@ import club.dnd5.portal.dto.api.RequestApi;
 import club.dnd5.portal.dto.api.spells.SearchRequest;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -23,6 +24,7 @@ public final class SpecificationUtil {
 		}
 		return specification.or(addSpecification);
 	}
+
 	public static <T> Specification<T> getSearch(RequestApi request) {
 		if (Optional.of(request).map(RequestApi::getSearch).map(SearchRequest::getExact).orElse(false)) {
 			return (root, query, cb) -> cb.equal(
@@ -36,12 +38,24 @@ public final class SpecificationUtil {
 				.orElse("")
 				.trim()
 				.toUpperCase() + "%";
-			return  (root, query, cb) ->
+			return (root, query, cb) ->
 				cb.or(
 					cb.like(cb.upper(root.get("altName")), likeSearch),
 					cb.like(cb.upper(root.get("englishName")), likeSearch),
 					cb.like(cb.upper(root.get("name")), likeSearch)
 				);
 		}
+	}
+
+	public static <T> Specification<T> combineWithOr(List<Specification<T>> specifications) {
+		Specification<T> combinedSpecification = null;
+		for (Specification<T> specification : specifications) {
+			if (combinedSpecification == null) {
+				combinedSpecification = specification;
+			} else {
+				combinedSpecification = combinedSpecification.or(specification);
+			}
+		}
+		return combinedSpecification;
 	}
 }


### PR DESCRIPTION
Revised the timecast filtering logic to ensure accurate spell retrieval. Now, the timecast filter functions as expected

Add **combineWithOr** method for Specifications

Implemented the `combineWithOr` method in SpecificationUtil. This method enables the combination of a list of specifications using logical OR operations, providing flexibility in constructing complex queries.