### PR TITLE
feat(seo): серверные canonical и мета-теги для страниц SPA

### DIFF
--- a/src/main/java/club/dnd5/portal/controller/SpaController.java
+++ b/src/main/java/club/dnd5/portal/controller/SpaController.java
@@ -1,18 +1,45 @@
 package club.dnd5.portal.controller;
 
+import club.dnd5.portal.controller.api.MetaApiController;
+import club.dnd5.portal.dto.api.MetaApi;
 import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 @Hidden
 @Controller
 public class SpaController {
-	private static final Resource INDEX = new ClassPathResource("templates/spa.html");
+	private static final ClassPathResource INDEX = new ClassPathResource("templates/spa.html");
+
+	// Канонический домен старого справочника (редакция 2014). На него ссылается
+	// self-canonical каждой страницы, чтобы сайт индексировался как самостоятельный
+	// и не схлопывался с новым сайтом (new.ttg.club, редакция 2024).
+	private static final String CANONICAL_ORIGIN = "https://5e14.ttg.club";
+
+	// index.html кэшируем в памяти: на каждый запрос лишь подставляем canonical,
+	// а не перечитываем ресурс с диска.
+	private static volatile String indexTemplate;
+
+	// Маркер редакции в серверном <title>/og:title — различимость от нового
+	// сайта (new.ttg.club, редакция 2024).
+	private static final String EDITION_SUFFIX = " (2014)";
+
+	// Резолвер title/description по пути запроса (переиспользует логику /api/v1/meta).
+	private final MetaApiController metaApiController;
+
+	public SpaController(MetaApiController metaApiController) {
+		this.metaApiController = metaApiController;
+	}
 
 	@GetMapping({
 		"/",
@@ -118,10 +145,73 @@ public class SpaController {
 		"/weapons/{name}"
 	})
 	@ResponseBody
-	public ResponseEntity<Resource> getIndex() {
+	public ResponseEntity<String> getIndex(HttpServletRequest request) throws IOException {
+		String path = request.getRequestURI();
+		if (path.length() > 1 && path.endsWith("/")) {
+			path = path.substring(0, path.length() - 1);
+		}
+
+		final StringBuilder head = new StringBuilder();
+
+		// self-canonical на текущий путь (в пределах этого домена).
+		head.append("<link rel=\"canonical\" href=\"")
+			.append(CANONICAL_ORIGIN).append(escapeHtmlAttr(path)).append("\"/>");
+
+		// Серверные title/description из тех же метаданных, что и /api/v1/meta,
+		// чтобы их видел Яндекс (без JS). null → просто не инжектим.
+		final MetaApi meta = metaApiController.resolveByPath(path);
+		if (meta != null) {
+			if (meta.getTitle() != null && !meta.getTitle().isEmpty()) {
+				final String title = escapeHtmlAttr(meta.getTitle() + EDITION_SUFFIX);
+				head.append("<title>").append(title).append("</title>");
+				head.append("<meta property=\"og:title\" content=\"").append(title).append("\"/>");
+			}
+			if (meta.getDescription() != null && !meta.getDescription().isEmpty()) {
+				final String description = escapeHtmlAttr(meta.getDescription());
+				head.append("<meta name=\"description\" content=\"").append(description).append("\"/>");
+				head.append("<meta property=\"og:description\" content=\"").append(description).append("\"/>");
+			}
+		}
+
+		final String html = getIndexTemplate().replace("</head>", head + "</head>");
+
 		return ResponseEntity
 			.ok()
-			.contentType(MediaType.TEXT_HTML)
-			.body(INDEX);
+			.contentType(new MediaType(MediaType.TEXT_HTML, StandardCharsets.UTF_8))
+			.body(html);
+	}
+
+	private static String getIndexTemplate() throws IOException {
+		String template = indexTemplate;
+		if (template == null) {
+			synchronized (SpaController.class) {
+				template = indexTemplate;
+				if (template == null) {
+					try (InputStream in = INDEX.getInputStream()) {
+						template = StreamUtils.copyToString(in, StandardCharsets.UTF_8);
+					}
+					indexTemplate = template;
+				}
+			}
+		}
+		return template;
+	}
+
+	// Экранируем путь перед вставкой в HTML-атрибут href: в URL попадают
+	// пользовательские сегменты ({name}) — защита от reflected XSS.
+	private static String escapeHtmlAttr(String value) {
+		final StringBuilder sb = new StringBuilder(value.length() + 16);
+		for (int i = 0; i < value.length(); i++) {
+			final char c = value.charAt(i);
+			switch (c) {
+				case '&': sb.append("&amp;"); break;
+				case '<': sb.append("&lt;"); break;
+				case '>': sb.append("&gt;"); break;
+				case '"': sb.append("&quot;"); break;
+				case '\'': sb.append("&#39;"); break;
+				default: sb.append(c);
+			}
+		}
+		return sb.toString();
 	}
 }

--- a/src/main/java/club/dnd5/portal/controller/SpaController.java
+++ b/src/main/java/club/dnd5/portal/controller/SpaController.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.util.HtmlUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
@@ -197,21 +198,11 @@ public class SpaController {
 		return template;
 	}
 
-	// Экранируем путь перед вставкой в HTML-атрибут href: в URL попадают
-	// пользовательские сегменты ({name}) — защита от reflected XSS.
+	// Экранируем значения перед вставкой в HTML (href/атрибуты/текст). В путь
+	// попадают пользовательские сегменты ({name}) — защита от reflected XSS.
+	// HtmlUtils.htmlEscape экранирует < > & " и распознаётся статическим
+	// анализом (CodeQL) как санитайзер.
 	private static String escapeHtmlAttr(String value) {
-		final StringBuilder sb = new StringBuilder(value.length() + 16);
-		for (int i = 0; i < value.length(); i++) {
-			final char c = value.charAt(i);
-			switch (c) {
-				case '&': sb.append("&amp;"); break;
-				case '<': sb.append("&lt;"); break;
-				case '>': sb.append("&gt;"); break;
-				case '"': sb.append("&quot;"); break;
-				case '\'': sb.append("&#39;"); break;
-				default: sb.append(c);
-			}
-		}
-		return sb.toString();
+		return HtmlUtils.htmlEscape(value);
 	}
 }

--- a/src/main/java/club/dnd5/portal/controller/api/MetaApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/MetaApiController.java
@@ -451,4 +451,77 @@ public class MetaApiController {
 		meta.setDescription(infoPage.getSubtitle());
 		return meta;
 	}
+
+	/**
+	 * Резолвит метаданные (title/description) по пути SPA-запроса, переиспользуя
+	 * ту же логику, что и REST-эндпоинты /api/v1/meta. Нужно для серверной
+	 * инъекции title/description в index.html (см. SpaController), чтобы их видели
+	 * поисковики — в первую очередь Яндекс, который не исполняет JS.
+	 * Возвращает null, если для пути нет метаданных или сущность не найдена —
+	 * тогда инъекция просто не выполняется (страница отдаётся как есть).
+	 */
+	public MetaApi resolveByPath(String path) {
+		try {
+			String p = path;
+			if (p.startsWith("/")) {
+				p = p.substring(1);
+			}
+			if (p.endsWith("/")) {
+				p = p.substring(0, p.length() - 1);
+			}
+			if (p.isEmpty()) {
+				return getNotMapping();
+			}
+			String[] s = p.split("/");
+			switch (s[0]) {
+				case "classes":
+					if (s.length == 1) return getClassesMeta();
+					if (s.length == 2) return getClassMeta(s[1]);
+					return getArchetypeMeta(s[1], s[2]);
+				case "races":
+					if (s.length == 1) return getRacesMeta();
+					if (s.length == 2) return getRaceMeta(s[1]);
+					return getSubraceMeta(s[1], s[2]).getBody();
+				case "traits":
+				case "feats":
+					return s.length == 1 ? getTraitsMeta() : getTraitMeta(s[1]);
+				case "backgrounds":
+					return s.length == 1 ? getBackgroundsMeta() : getBackgroundMeta(s[1]);
+				case "options":
+					return s.length == 1 ? getOptionsMeta() : getOptiondMeta(s[1]);
+				case "spells":
+					return s.length == 1 ? getSpellsMeta() : getSpellMeta(s[1]);
+				case "weapons":
+					return s.length == 1 ? getWeaponsMeta() : getWeaponMeta(s[1]);
+				case "armors":
+					return s.length == 1 ? getArmorsMeta() : getArmorMeta(s[1]);
+				case "items":
+					if (s.length == 1) return getItemsMeta();
+					if ("magic".equals(s[1])) {
+						return s.length == 2 ? getMagicItemsMeta() : getMagicItemMeta(s[2]);
+					}
+					return getItemMeta(s[1]);
+				case "magic-items":
+					return s.length == 1 ? getMagicItemsMeta() : getMagicItemMeta(s[1]);
+				case "bestiary":
+					return s.length == 1 ? getBeastsMeta() : getBeastMeta(s[1]);
+				case "screens":
+					return s.length == 1 ? getScreensMeta() : getScreenMeta(s[1]);
+				case "gods":
+					return s.length == 1 ? getGodsMeta() : getGodMeta(s[1]);
+				case "rules":
+					return s.length == 1 ? getRulesMeta() : getRuleMeta(s[1]);
+				case "books":
+					return s.length == 1 ? getBooksMeta() : getBooksMeta(s[1]);
+				case "info":
+					return s.length >= 2 ? getInfoMeta(s[1]) : null;
+				case "tools":
+					return (s.length >= 2 && "tokenator".equals(s[1])) ? getTokenatorMeta() : null;
+				default:
+					return null;
+			}
+		} catch (Exception e) {
+			return null;
+		}
+	}
 }

--- a/src/main/resources/robots.txt
+++ b/src/main/resources/robots.txt
@@ -13,5 +13,4 @@ Disallow: /reset
 Disallow: /api
 Disallow: /css
 
-Sitemap: https://ttg.club/sitemap.xml
-Host: ttg.club
+Sitemap: https://5e14.ttg.club/sitemap.xml


### PR DESCRIPTION
Старый справочник (5e14.ttg.club, редакция 2014) вытеснялся из поиска новым сайтом (2024): его страницы — клиентский SPA без серверных canonical и уникальных title/description, поэтому для краулеров (в первую очередь Яндекса, не исполняющего JS) выглядели одинаковыми пустыми оболочками-дублями. Теперь нужные SEO-теги рендерятся на сервере при отдаче index.html.

- SpaController: на каждый запрос страницы инжектит в <head>:
  - self-canonical на текущий путь (https://5e14.ttg.club{путь});
  - серверный <title> с маркером редакции «(2014)» — различимость от нового сайта;
  - <meta name="description"> и og:title/og:description. Шаблон index.html кэшируется в памяти, значения экранируются (защита от reflected XSS в пользовательских сегментах URL), ответ отдаётся в UTF-8.

- MetaApiController: добавлен resolveByPath(path) — резолвит метаданные по пути SPA-запроса, переиспользуя существующую логику эндпоинтов /api/v1/meta (разделы и детальные страницы). Если метаданных для пути нет или сущность не найдена — возвращает null и инъекция не выполняется (страница отдаётся как прежде).

- robots.txt: Sitemap переведён на https://5e14.ttg.club/sitemap.xml (вместо
  редиректящего ttg.club), удалена устаревшая директива Host: ttg.club.