### PR TITLE
feat(комментарии): прокси /api/v1/comments на сервис комментариев

### DIFF
--- a/src/main/java/club/dnd5/portal/config/WebSecurityConfig.java
+++ b/src/main/java/club/dnd5/portal/config/WebSecurityConfig.java
@@ -66,6 +66,10 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter implements W
         	.antMatchers(HttpMethod.POST, "/api/v1/**").permitAll()
         	.antMatchers(HttpMethod.PATCH, "/api/v1/**").permitAll()
         	.antMatchers("/api/v1/auth/**").permitAll()
+        	// Прокси комментариев (CommentsProxyController): контроль доступа целиком
+        	// на стороне сервиса comments.ttg.club (он проверяет тот же SSO-JWT).
+        	// Явное правило нужно ради DELETE — остальные методы уже открыты выше.
+        	.antMatchers("/api/v1/comments/**").permitAll()
         	// Трекер инициативы: анонимный доступ разрешён (создание анонимного трекера и работа
         	// по ключу X-Tracker-Key); контроль доступа — в сервисе (владелец по JWT либо ключ).
         	.antMatchers("/api/v2/tools/initiative/**").permitAll()

--- a/src/main/java/club/dnd5/portal/controller/api/BackgroundApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/BackgroundApiController.java
@@ -131,9 +131,9 @@ public class BackgroundApiController {
 			.ifPresent(existing -> {
 				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Background with the same englishName already exists");
 			});
+		auditService.record(ENTITY_TYPE, id, RevisionOperation.UPDATE, new BackgroundSaveApi(background));
 		applyBackgroundRequest(background, request);
 		Background saved = backgroundRepository.saveAndFlush(background);
-		auditService.record(ENTITY_TYPE, saved.getId(), RevisionOperation.UPDATE, request);
 		return ResponseEntity.ok(new BackgroundDetailApi(saved));
 	}
 

--- a/src/main/java/club/dnd5/portal/controller/api/ClassApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/ClassApiController.java
@@ -142,12 +142,13 @@ public class ClassApiController {
 			.ifPresent(existing -> {
 				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Class with the same englishName already exists");
 		});
+		auditService.record(ENTITY_TYPE_CLASS, id, RevisionOperation.UPDATE,
+			new ClassSaveApi(heroClass, heroClassTraitRepository.findAllByHeroClassIdAndArchitypeFalse(id)));
 		applyClassRequest(heroClass, request);
 		HeroClass saved = classRepo.saveAndFlush(heroClass);
 		syncClassTraits(saved, request);
 		saved.setTraits(heroClassTraitRepository.findAllByHeroClassIdAndArchitypeFalse(saved.getId()));
 		Collection<String> images = imageRepository.findAllByTypeAndRefId(ImageType.CLASS, saved.getId());
-		auditService.record(ENTITY_TYPE_CLASS, saved.getId(), RevisionOperation.UPDATE, request);
 		return ResponseEntity.ok(new ClassDetailApi(saved, images, new ClassRequestApi()));
 	}
 
@@ -194,6 +195,8 @@ public class ClassApiController {
 			.filter(existing -> !existing.getId().equals(id)).ifPresent(existing -> {
 				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Archetype with the same englishName already exists");
 			});
+		auditService.record(ENTITY_TYPE_ARCHETYPE, id, RevisionOperation.UPDATE,
+			new ArchetypeSaveApi(archetype, archetypeTraitRepository.findAllByArchetypeId(id)));
 		archetype.setName(request.getName().trim()); archetype.setEnglishName(request.getEnglishName().trim());
 		archetype.setGenitiveName(trimToNull(request.getGenitiveName())); archetype.setDescription(request.getDescription().trim());
 		archetype.setLevel(request.getLevel()); archetype.setSpellcasterType(request.getSpellcasterType());
@@ -201,7 +204,6 @@ public class ClassApiController {
 		Archetype saved = archetypeRepository.saveAndFlush(archetype);
 		syncArchetypeTraits(saved, request);
 		saved.setFeats(archetypeTraitRepository.findAllByArchetypeId(saved.getId()));
-		auditService.record(ENTITY_TYPE_ARCHETYPE, saved.getId(), RevisionOperation.UPDATE, request);
 		return new ArchetypeEditApi(saved);
 	}
 

--- a/src/main/java/club/dnd5/portal/controller/api/FeatApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/FeatApiController.java
@@ -145,9 +145,9 @@ public class FeatApiController {
 			.ifPresent(existing -> {
 				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Feat with the same englishName already exists");
 			});
+		auditService.record(ENTITY_TYPE, id, RevisionOperation.UPDATE, new FeatSaveApi(trait));
 		applyFeatRequest(trait, request);
 		Trait saved = featRepository.saveAndFlush(trait);
-		auditService.record(ENTITY_TYPE, saved.getId(), RevisionOperation.UPDATE, request);
 		return ResponseEntity.ok(new FeatDetailApi(saved));
 	}
 

--- a/src/main/java/club/dnd5/portal/controller/api/OptionApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/OptionApiController.java
@@ -148,9 +148,9 @@ public class OptionApiController {
 			.ifPresent(existing -> {
 				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Option with the same englishName already exists");
 			});
+		auditService.record(ENTITY_TYPE, id, RevisionOperation.UPDATE, new OptionSaveApi(option));
 		applyOptionRequest(option, request);
 		Option saved = optionRepository.saveAndFlush(option);
-		auditService.record(ENTITY_TYPE, saved.getId(), RevisionOperation.UPDATE, request);
 		return ResponseEntity.ok(new OptionDetailApi(saved));
 	}
 

--- a/src/main/java/club/dnd5/portal/controller/api/RacesApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/RacesApiController.java
@@ -221,6 +221,8 @@ public class RacesApiController {
 			.ifPresent(existing -> {
 				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Race with the same englishName already exists");
 			});
+		auditService.record(ENTITY_TYPE, id, RevisionOperation.UPDATE,
+			new RaceSaveApi(race, raceAbilityBonusRepository.findAllByRaceId(id), raceFeatureRepository.findAllByRaceId(id)));
 		applyRaceRequest(race, request);
 		Race saved = raceRepository.saveAndFlush(race);
 		syncAbilities(saved, request);
@@ -232,7 +234,6 @@ public class RacesApiController {
 		if (!images.isEmpty()) {
 			raceApi.setImages(images);
 		}
-		auditService.record(ENTITY_TYPE, saved.getId(), RevisionOperation.UPDATE, request);
 		return ResponseEntity.ok(raceApi);
 	}
 

--- a/src/main/java/club/dnd5/portal/controller/api/SpellApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/SpellApiController.java
@@ -269,10 +269,10 @@ public class SpellApiController {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Spell with the same englishName already exists");
 		}
 
+		auditService.record(ENTITY_TYPE, id, RevisionOperation.UPDATE, new SpellSaveApi(spell));
 		applySpellRequest(spell, request);
 		saveTimeCast(spell, request);
 		Spell saved = spellRepository.saveAndFlush(spell);
-		auditService.record(ENTITY_TYPE, saved.getId(), RevisionOperation.UPDATE, request);
 		return ResponseEntity.ok(getSpellDetail(saved));
 	}
 

--- a/src/main/java/club/dnd5/portal/controller/api/item/ArmorApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/item/ArmorApiController.java
@@ -123,9 +123,9 @@ public class ArmorApiController {
 			.ifPresent(existing -> {
 				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Armor with the same englishName already exists");
 			});
+		auditService.record(ENTITY_TYPE, id, RevisionOperation.UPDATE, new ArmorSaveApi(armor));
 		applyArmorRequest(armor, request);
 		Armor saved = armorRepository.saveAndFlush(armor);
-		auditService.record(ENTITY_TYPE, saved.getId(), RevisionOperation.UPDATE, request);
 		return new ArmorDetailApi(saved);
 	}
 

--- a/src/main/java/club/dnd5/portal/controller/api/item/ItemApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/item/ItemApiController.java
@@ -139,9 +139,9 @@ public class ItemApiController {
 			.ifPresent(existing -> {
 				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Item with the same englishName already exists");
 			});
+		auditService.record(ENTITY_TYPE, id, RevisionOperation.UPDATE, new ItemSaveApi(item));
 		applyItemRequest(item, request);
 		Equipment saved = itemRepository.saveAndFlush(item);
-		auditService.record(ENTITY_TYPE, saved.getId(), RevisionOperation.UPDATE, request);
 		return new ItemDetailApi(saved);
 	}
 

--- a/src/main/java/club/dnd5/portal/controller/api/item/MagicItemApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/item/MagicItemApiController.java
@@ -166,9 +166,9 @@ public class MagicItemApiController {
 			.ifPresent(existing -> {
 				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Magic item with the same englishName already exists");
 			});
+		auditService.record(ENTITY_TYPE, id, RevisionOperation.UPDATE, new MagicItemSaveApi(item));
 		applyItemRequest(item, request);
 		MagicItem saved = magicItemRepository.saveAndFlush(item);
-		auditService.record(ENTITY_TYPE, saved.getId(), RevisionOperation.UPDATE, request);
 		return new MagicItemDetailApi(saved);
 	}
 

--- a/src/main/java/club/dnd5/portal/controller/api/item/WeaponApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/item/WeaponApiController.java
@@ -150,9 +150,9 @@ public class WeaponApiController {
 			.ifPresent(existing -> {
 				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Weapon with the same englishName already exists");
 			});
+		auditService.record(ENTITY_TYPE, id, RevisionOperation.UPDATE, new WeaponSaveApi(weapon));
 		applyWeaponRequest(weapon, request);
 		Weapon saved = weaponRepository.saveAndFlush(weapon);
-		auditService.record(ENTITY_TYPE, saved.getId(), RevisionOperation.UPDATE, request);
 		return new WeaponDetailApi(saved);
 	}
 

--- a/src/main/java/club/dnd5/portal/controller/api/user/UserProfileController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/user/UserProfileController.java
@@ -1,0 +1,153 @@
+package club.dnd5.portal.controller.api.user;
+
+import club.dnd5.portal.dto.user.DisplayNameDto;
+import club.dnd5.portal.model.user.User;
+import club.dnd5.portal.repository.user.UserRepository;
+import club.dnd5.portal.security.ExternalAuthClient;
+import club.dnd5.portal.security.ExternalAuthUser;
+import club.dnd5.portal.service.CommentsRenameClient;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Профиль пользователя: отображаемое имя для комментариев. Хранится локально в {@code users}
+ * (колонка {@code display_name}); {@code null} — показывается логин.
+ * <p>
+ * Смена имени и публикация комментария синхронизируют снимок имени в сервисе комментариев:
+ * тот стамперит логин из токена, а {@link CommentsRenameClient} приводит его к отображаемому
+ * имени в комментариях этого сайта (скоуп по платформе).
+ */
+@Tag(name = "Профиль пользователя", description = "Отображаемое имя для комментариев")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/user")
+@Validated
+public class UserProfileController {
+    private static final String USER_TOKEN_COOKIE = "dnd5_user_token";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final UserRepository userRepository;
+    private final ExternalAuthClient externalAuthClient;
+    private final CommentsRenameClient commentsRenameClient;
+
+    @GetMapping("/display-name")
+    public ResponseEntity<DisplayNameDto> getDisplayName() {
+        return currentUser()
+                .map(user -> ResponseEntity.ok(new DisplayNameDto(user.getDisplayName())))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED).build());
+    }
+
+    @PatchMapping("/display-name")
+    public ResponseEntity<DisplayNameDto> updateDisplayName(
+            @Valid @RequestBody DisplayNameDto request) {
+        Optional<User> current = currentUser();
+        if (!current.isPresent()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String displayName = request.getDisplayName().trim();
+
+        User user = current.get();
+        user.setDisplayName(displayName);
+        userRepository.save(user);
+
+        // Сразу приводим имя в уже оставленных комментариях к новому (best-effort).
+        syncCommentsName(displayName);
+
+        return ResponseEntity.ok(new DisplayNameDto(displayName));
+    }
+
+    /**
+     * Приводит имя автора в комментариях к текущему отображаемому имени. Зовётся фронтом
+     * после публикации комментария: сервис стамперит логин, этот вызов заменяет его на имя.
+     * Без заданного имени синхронизировать нечего.
+     */
+    @PostMapping("/comments/sync-name")
+    public ResponseEntity<Map<String, Boolean>> syncCommentsName() {
+        Optional<User> current = currentUser();
+        if (!current.isPresent()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String displayName = current.get().getDisplayName();
+        if (!StringUtils.hasText(displayName)) {
+            return ResponseEntity.ok(Collections.singletonMap("synced", false));
+        }
+
+        boolean synced = syncCommentsName(displayName);
+        return ResponseEntity.ok(Collections.singletonMap("synced", synced));
+    }
+
+    /**
+     * Дёргает рену comments-service с UUID автора из токена. UUID (клейм {@code sub}) в
+     * SecurityContext не лежит — там только логин, — поэтому берём его из auth-service по
+     * токену запроса. Best-effort: без токена или при ошибке — false, имя подхватится позже.
+     */
+    private boolean syncCommentsName(String displayName) {
+        String token = extractToken(currentRequest());
+        if (!StringUtils.hasText(token)) {
+            return false;
+        }
+
+        try {
+            ExternalAuthUser authUser = externalAuthClient.me(token);
+            return commentsRenameClient.rename(authUser.getId(), displayName);
+        } catch (RuntimeException error) {
+            return false;
+        }
+    }
+
+    /** Текущий пользователь из локальной таблицы по имени принципала (логин/email). */
+    private Optional<User> currentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
+            return Optional.empty();
+        }
+
+        return userRepository.findByEmailOrUsername(authentication.getName(), authentication.getName());
+    }
+
+    private static HttpServletRequest currentRequest() {
+        return ((org.springframework.web.context.request.ServletRequestAttributes)
+                org.springframework.web.context.request.RequestContextHolder
+                        .currentRequestAttributes()).getRequest();
+    }
+
+    /** Токен из заголовка Authorization, иначе из куки — как в AuthServiceAuthenticationFilter. */
+    private static String extractToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length());
+        }
+
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (USER_TOKEN_COOKIE.equals(cookie.getName()) && StringUtils.hasText(cookie.getValue())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/club/dnd5/portal/controller/proxy/CommentsProxyController.java
+++ b/src/main/java/club/dnd5/portal/controller/proxy/CommentsProxyController.java
@@ -134,20 +134,16 @@ public class CommentsProxyController {
      * Запрещаем любые попытки выйти за origin/prefix базового URL.
      */
     private URI targetUri(HttpServletRequest request) {
+        // Путь запроса ({@code /api/v1/comments/count}) форвардится в сервис как есть:
+        // base-url — это origin сервиса (без пути), а comments-service отдаёт публичный
+        // API под тем же префиксом {@code /api/v1/comments/**}. Префикс срезать нельзя —
+        // иначе в сервис уходит {@code /count}, которого у него нет, и security отвечает
+        // 401 (неизвестный путь требует авторизации) даже гостю.
         String requestUri = request.getRequestURI();
         String query = request.getQueryString();
 
-        String pathWithinProxy = requestUri;
-        String mappingPrefix = "/api/v1/comments";
-        if (pathWithinProxy.startsWith(mappingPrefix)) {
-            pathWithinProxy = pathWithinProxy.substring(mappingPrefix.length());
-        }
-        if (!pathWithinProxy.startsWith("/")) {
-            pathWithinProxy = "/" + pathWithinProxy;
-        }
-
         URI resolved = UriComponentsBuilder.fromUri(baseUri)
-                .replacePath(baseUri.getPath() + pathWithinProxy)
+                .replacePath(baseUri.getPath() + requestUri)
                 .replaceQuery(query)
                 .build(true)
                 .toUri()

--- a/src/main/java/club/dnd5/portal/controller/proxy/CommentsProxyController.java
+++ b/src/main/java/club/dnd5/portal/controller/proxy/CommentsProxyController.java
@@ -17,11 +17,13 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Locale;
 
 /**
  * Прокси публичного API сервиса комментариев (comments.ttg.club).
@@ -56,9 +58,11 @@ public class CommentsProxyController {
 
     private final RestTemplate restTemplate = buildRestTemplate();
     private final String baseUrl;
+    private final URI baseUri;
 
     public CommentsProxyController(@Value("${comments-service.base-url}") String baseUrl) {
         this.baseUrl = trimTrailingSlash(baseUrl);
+        this.baseUri = URI.create(this.baseUrl);
     }
 
     @RequestMapping({"", "/**"})
@@ -94,6 +98,8 @@ public class CommentsProxyController {
                     byte[].class);
 
             return relay(upstream);
+        } catch (IllegalArgumentException invalidTarget) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         } catch (ResourceAccessException connectionError) {
             // Сервис недоступен (таймаут, отказ соединения) — отдаём 502, чтобы
             // фронт показал ошибку загрузки, а не пустой 500 монолита.
@@ -123,20 +129,55 @@ public class CommentsProxyController {
     }
 
     /**
-     * Полный адрес запроса к сервису: базовый URL плюс путь и query как есть.
-     * Путь и строка запроса берутся из сервлета уже закодированными, поэтому
-     * повторного кодирования не требуется — используется URI-перегрузка
-     * exchange (без раскрытия шаблонных переменных).
+     * Полный адрес запроса к сервису: только в пределах настроенного baseUrl.
+     * Запрещаем любые попытки выйти за origin/prefix базового URL.
      */
     private URI targetUri(HttpServletRequest request) {
-        StringBuilder target = new StringBuilder(baseUrl).append(request.getRequestURI());
-
+        String requestUri = request.getRequestURI();
         String query = request.getQueryString();
-        if (StringUtils.hasText(query)) {
-            target.append('?').append(query);
+
+        String pathWithinProxy = requestUri;
+        String mappingPrefix = "/api/v1/comments";
+        if (pathWithinProxy.startsWith(mappingPrefix)) {
+            pathWithinProxy = pathWithinProxy.substring(mappingPrefix.length());
+        }
+        if (!pathWithinProxy.startsWith("/")) {
+            pathWithinProxy = "/" + pathWithinProxy;
         }
 
-        return URI.create(target.toString());
+        URI resolved = UriComponentsBuilder.fromUri(baseUri)
+                .replacePath(baseUri.getPath() + pathWithinProxy)
+                .replaceQuery(query)
+                .build(true)
+                .toUri()
+                .normalize();
+
+        if (!sameOrigin(baseUri, resolved)) {
+            throw new IllegalArgumentException("Resolved URI is outside configured origin");
+        }
+
+        String basePath = baseUri.getPath() == null ? "" : baseUri.getPath();
+        String resolvedPath = resolved.getPath() == null ? "" : resolved.getPath();
+        if (!resolvedPath.startsWith(basePath + "/") && !resolvedPath.equals(basePath)) {
+            throw new IllegalArgumentException("Resolved URI is outside configured path prefix");
+        }
+
+        return resolved;
+    }
+
+    private boolean sameOrigin(URI expectedBase, URI candidate) {
+        String expectedScheme = expectedBase.getScheme() == null ? "" : expectedBase.getScheme().toLowerCase(Locale.ROOT);
+        String candidateScheme = candidate.getScheme() == null ? "" : candidate.getScheme().toLowerCase(Locale.ROOT);
+
+        String expectedHost = expectedBase.getHost() == null ? "" : expectedBase.getHost().toLowerCase(Locale.ROOT);
+        String candidateHost = candidate.getHost() == null ? "" : candidate.getHost().toLowerCase(Locale.ROOT);
+
+        int expectedPort = expectedBase.getPort();
+        int candidatePort = candidate.getPort();
+
+        return expectedScheme.equals(candidateScheme)
+                && expectedHost.equals(candidateHost)
+                && expectedPort == candidatePort;
     }
 
     /**

--- a/src/main/java/club/dnd5/portal/controller/proxy/CommentsProxyController.java
+++ b/src/main/java/club/dnd5/portal/controller/proxy/CommentsProxyController.java
@@ -1,0 +1,192 @@
+package club.dnd5.portal.controller.proxy;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Прокси публичного API сервиса комментариев (comments.ttg.club).
+ * <p>
+ * Старый сайт — статический SPA, который отдаёт этот же Spring-монолит, поэтому
+ * запрос фронта на относительный {@code /api/v1/comments/**} приходит сюда, а не
+ * в отдельный сервер приложения (в отличие от нового сайта, где ту же роль
+ * играет Nitro-сервер Nuxt). Без этого форварда путь упирается в отсутствующий
+ * контроллер и отдаёт 404.
+ * <p>
+ * Сервис комментариев проверяет тот же SSO-JWT auth-service, но ждёт его в
+ * заголовке {@code Authorization: Bearer}, а фронт в проде шлёт токен кукой
+ * {@code dnd5_user_token} (заголовок не выставляет). Поэтому токен извлекается
+ * так же, как в {@code AuthServiceAuthenticationFilter}, и подставляется
+ * заголовком в исходящий запрос. Гостю токена нет — чтение открыто, форвард
+ * уходит без {@code Authorization}.
+ * <p>
+ * Ответы сервиса, включая 4xx/5xx, отдаются фронту как есть: он разбирает тело
+ * ProblemDetail (поле {@code detail}) и заголовок {@code Retry-After} у 429.
+ * Поэтому обработчик ошибок RestTemplate отключён — иначе он бросил бы
+ * исключение и подменил бы значимый ответ сервиса на 500.
+ */
+@Hidden
+@RestController
+@RequestMapping("/api/v1/comments")
+public class CommentsProxyController {
+    private static final String USER_TOKEN_COOKIE = "dnd5_user_token";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private static final int CONNECT_TIMEOUT_MS = 5_000;
+    private static final int READ_TIMEOUT_MS = 15_000;
+
+    private final RestTemplate restTemplate = buildRestTemplate();
+    private final String baseUrl;
+
+    public CommentsProxyController(@Value("${comments-service.base-url}") String baseUrl) {
+        this.baseUrl = trimTrailingSlash(baseUrl);
+    }
+
+    @RequestMapping({"", "/**"})
+    public ResponseEntity<byte[]> forward(HttpServletRequest request,
+                                          @RequestBody(required = false) byte[] body) {
+        HttpHeaders headers = new HttpHeaders();
+
+        String contentType = request.getHeader(HttpHeaders.CONTENT_TYPE);
+        if (StringUtils.hasText(contentType)) {
+            headers.set(HttpHeaders.CONTENT_TYPE, contentType);
+        }
+
+        String accept = request.getHeader(HttpHeaders.ACCEPT);
+        if (StringUtils.hasText(accept)) {
+            headers.set(HttpHeaders.ACCEPT, accept);
+        }
+
+        String token = extractToken(request);
+        if (token != null) {
+            headers.set(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + token);
+        }
+
+        HttpMethod method = HttpMethod.resolve(request.getMethod());
+        if (method == null) {
+            return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).build();
+        }
+
+        try {
+            ResponseEntity<byte[]> upstream = restTemplate.exchange(
+                    targetUri(request),
+                    method,
+                    new HttpEntity<>(body, headers),
+                    byte[].class);
+
+            return relay(upstream);
+        } catch (ResourceAccessException connectionError) {
+            // Сервис недоступен (таймаут, отказ соединения) — отдаём 502, чтобы
+            // фронт показал ошибку загрузки, а не пустой 500 монолита.
+            return ResponseEntity.status(HttpStatus.BAD_GATEWAY).build();
+        }
+    }
+
+    /**
+     * Копирует апстрим-ответ фронту, перенося только те заголовки, от которых
+     * он зависит: тип содержимого (разбор JSON/ProblemDetail) и Retry-After
+     * (пауза антиспам-лимита у 429). Остальное проставит контейнер.
+     */
+    private ResponseEntity<byte[]> relay(ResponseEntity<byte[]> upstream) {
+        HttpHeaders headers = new HttpHeaders();
+
+        MediaType contentType = upstream.getHeaders().getContentType();
+        if (contentType != null) {
+            headers.setContentType(contentType);
+        }
+
+        String retryAfter = upstream.getHeaders().getFirst(HttpHeaders.RETRY_AFTER);
+        if (StringUtils.hasText(retryAfter)) {
+            headers.set(HttpHeaders.RETRY_AFTER, retryAfter);
+        }
+
+        return new ResponseEntity<>(upstream.getBody(), headers, upstream.getStatusCode());
+    }
+
+    /**
+     * Полный адрес запроса к сервису: базовый URL плюс путь и query как есть.
+     * Путь и строка запроса берутся из сервлета уже закодированными, поэтому
+     * повторного кодирования не требуется — используется URI-перегрузка
+     * exchange (без раскрытия шаблонных переменных).
+     */
+    private URI targetUri(HttpServletRequest request) {
+        StringBuilder target = new StringBuilder(baseUrl).append(request.getRequestURI());
+
+        String query = request.getQueryString();
+        if (StringUtils.hasText(query)) {
+            target.append('?').append(query);
+        }
+
+        return URI.create(target.toString());
+    }
+
+    /**
+     * Токен пользователя — из заголовка Authorization, иначе из куки. Копия
+     * логики {@code AuthServiceAuthenticationFilter}: фронт в проде токен в
+     * заголовке не шлёт, только кукой.
+     */
+    private String extractToken(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(header) && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length());
+        }
+
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (USER_TOKEN_COOKIE.equals(cookie.getName()) && StringUtils.hasText(cookie.getValue())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static RestTemplate buildRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        factory.setReadTimeout(READ_TIMEOUT_MS);
+
+        RestTemplate template = new RestTemplate(factory);
+
+        // Не бросать на 4xx/5xx: значимый ответ сервиса (ProblemDetail, 429 с
+        // Retry-After, 409 «уже удалён») должен дойти до фронта, а не
+        // превратиться в исключение и 500.
+        template.setErrorHandler(new DefaultResponseErrorHandler() {
+            @Override
+            public boolean hasError(ClientHttpResponse response) throws IOException {
+                return false;
+            }
+        });
+
+        return template;
+    }
+
+    private static String trimTrailingSlash(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        String trimmed = value.trim();
+        return trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+    }
+}

--- a/src/main/java/club/dnd5/portal/controller/proxy/CommentsProxyController.java
+++ b/src/main/java/club/dnd5/portal/controller/proxy/CommentsProxyController.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Прокси публичного API сервиса комментариев (comments.ttg.club).
@@ -57,6 +58,19 @@ public class CommentsProxyController {
 
     private static final int CONNECT_TIMEOUT_MS = 5_000;
     private static final int READ_TIMEOUT_MS = 15_000;
+
+    // Allowlist пути форварда: префикс контроллера плюс сегменты из букв/цифр и
+    // `-._~`. Каждый сегмент обязан начинаться с буквы или цифры — это отсекает
+    // `..` (в том числе одиночную точку в начале сегмента) и любой скрытый обход
+    // каталога. Завершающий слэш допустим.
+    private static final Pattern SAFE_FORWARD_PATH =
+            Pattern.compile("/api/v1/comments(?:/[A-Za-z0-9][A-Za-z0-9._~-]*)*/?");
+
+    // Allowlist query: набор символов, легальных в query по RFC 3986 (pchar плюс
+    // `/?`), включая процент-кодирование. Пробелы, управляющие символы и всё, что
+    // способно повлиять на разбор URL, сюда не входят и отклоняются.
+    private static final Pattern SAFE_FORWARD_QUERY =
+            Pattern.compile("[A-Za-z0-9._~!$&'()*+,;=:@/?%-]*");
 
     private final RestTemplate restTemplate = buildRestTemplate();
     private final URI baseUri;
@@ -141,6 +155,18 @@ public class CommentsProxyController {
         // 401 (неизвестный путь требует авторизации) даже гостю.
         String requestUri = request.getRequestURI();
         String query = request.getQueryString();
+
+        // Валидация пользовательского ввода allowlist-ом ДО того, как он попадёт
+        // в исходящий URI: отсекаем символы, способные изменить authority
+        // (`:@`, обратный слэш, whitespace, управляющие) и обход каталога (`..`).
+        // Несовпадение — 400 (см. catch в forward). Это же обрывает поток
+        // «пользовательский ввод → URL» для статического анализа (SSRF).
+        if (!SAFE_FORWARD_PATH.matcher(requestUri).matches()) {
+            throw new IllegalArgumentException("Request path is not allowed");
+        }
+        if (query != null && !SAFE_FORWARD_QUERY.matcher(query).matches()) {
+            throw new IllegalArgumentException("Query string is not allowed");
+        }
 
         URI resolved = UriComponentsBuilder.fromUri(baseUri)
                 .replacePath(baseUri.getPath() + requestUri)

--- a/src/main/java/club/dnd5/portal/controller/proxy/CommentsProxyController.java
+++ b/src/main/java/club/dnd5/portal/controller/proxy/CommentsProxyController.java
@@ -1,6 +1,7 @@
 package club.dnd5.portal.controller.proxy;
 
 import io.swagger.v3.oas.annotations.Hidden;
+import lombok.NonNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -22,6 +23,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.Locale;
 
@@ -57,12 +59,11 @@ public class CommentsProxyController {
     private static final int READ_TIMEOUT_MS = 15_000;
 
     private final RestTemplate restTemplate = buildRestTemplate();
-    private final String baseUrl;
     private final URI baseUri;
 
     public CommentsProxyController(@Value("${comments-service.base-url}") String baseUrl) {
-        this.baseUrl = trimTrailingSlash(baseUrl);
-        this.baseUri = URI.create(this.baseUrl);
+        String baseUrl1 = trimTrailingSlash(baseUrl);
+        this.baseUri = URI.create(baseUrl1);
     }
 
     @RequestMapping({"", "/**"})
@@ -203,7 +204,16 @@ public class CommentsProxyController {
     }
 
     private static RestTemplate buildRestTemplate() {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        // Не следовать за редиректами апстрима: origin проверяется только на
+        // исходном URI, а 3xx мог бы увести запрос на внутренний адрес (SSRF).
+        // Прокси должен отдать редирект фронту, а не ходить по нему сам.
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory() {
+            @Override
+            protected void prepareConnection(@NonNull HttpURLConnection connection, @NonNull String httpMethod) throws IOException {
+                super.prepareConnection(connection, httpMethod);
+                connection.setInstanceFollowRedirects(false);
+            }
+        };
         factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
         factory.setReadTimeout(READ_TIMEOUT_MS);
 
@@ -214,7 +224,7 @@ public class CommentsProxyController {
         // превратиться в исключение и 500.
         template.setErrorHandler(new DefaultResponseErrorHandler() {
             @Override
-            public boolean hasError(ClientHttpResponse response) throws IOException {
+            public boolean hasError(@NonNull ClientHttpResponse response) {
                 return false;
             }
         });

--- a/src/main/java/club/dnd5/portal/dto/api/UserApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/UserApi.java
@@ -18,12 +18,14 @@ public class UserApi {
 	private String username;
 	private String name;
 	private String email;
+	private String displayName;
 	private List<String> roles;
 
 	public UserApi(User user) {
 		username = user.getUsername();
 		name = user.getName();
 		email = user.getEmail();
+		displayName = user.getDisplayName();
 		roles = user.getRoles().stream().map(Role::getName).collect(Collectors.toList());
 	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/classes/ArchetypeSaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/classes/ArchetypeSaveApi.java
@@ -2,6 +2,8 @@ package club.dnd5.portal.dto.api.classes;
 
 import club.dnd5.portal.model.SpellcasterType;
 import club.dnd5.portal.model.classes.Option;
+import club.dnd5.portal.model.classes.archetype.Archetype;
+import club.dnd5.portal.model.classes.archetype.ArchetypeTrait;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -24,4 +26,20 @@ public class ArchetypeSaveApi {
 	private Option.OptionType optionType;
 	private Short page;
 	private List<ClassTraitSaveApi> traits;
+
+	public ArchetypeSaveApi(Archetype archetype) {
+		this(archetype, archetype.getFeats());
+	}
+
+	public ArchetypeSaveApi(Archetype archetype, List<ArchetypeTrait> archetypeTraits) {
+		name = archetype.getName();
+		englishName = archetype.getEnglishName();
+		genitiveName = archetype.getGenitiveName();
+		description = archetype.getDescription();
+		level = archetype.getLevel();
+		spellcasterType = archetype.getSpellcasterType();
+		optionType = archetype.getOptionType();
+		page = archetype.getPage();
+		traits = archetypeTraits.stream().map(ClassTraitSaveApi::new).collect(java.util.stream.Collectors.toList());
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/classes/BackgroundSaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/classes/BackgroundSaveApi.java
@@ -2,6 +2,8 @@ package club.dnd5.portal.dto.api.classes;
 
 import club.dnd5.portal.model.SkillType;
 import club.dnd5.portal.model.background.LifeStyle;
+import club.dnd5.portal.model.background.Background;
+import club.dnd5.portal.model.Language;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -34,4 +36,24 @@ public class BackgroundSaveApi {
 
 	/** Аббревиатура книги-источника, например MM. Пусто — самодельный контент. */
 	private String source;
+
+	public BackgroundSaveApi(Background background) {
+		name = background.getName();
+		englishName = background.getEnglishName();
+		altName = background.getAltName();
+		skills = background.getSkills();
+		otherSkills = background.getOtherSkills();
+		toolOwnership = background.getToolOwnership();
+		equipments = background.getEquipmentsText();
+		startGold = background.getStartMoney();
+		description = background.getDescription();
+		skillName = background.getSkillName();
+		skillDescription = background.getSkillDescription();
+		personalization = background.getPersonalization();
+		language = background.getLanguage();
+		languages = background.getLanguages() == null ? java.util.Collections.emptyList()
+			: background.getLanguages().stream().map(Language::getName).collect(java.util.stream.Collectors.toList());
+		lifeStyle = background.getLifeStyle();
+		source = background.getBook() == null ? null : background.getBook().getSource();
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/classes/ClassSaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/classes/ClassSaveApi.java
@@ -5,6 +5,8 @@ import club.dnd5.portal.model.Rest;
 import club.dnd5.portal.model.SkillType;
 import club.dnd5.portal.model.SpellcasterType;
 import club.dnd5.portal.model.classes.Option;
+import club.dnd5.portal.model.classes.HeroClass;
+import club.dnd5.portal.model.classes.HeroClassTrait;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -50,4 +52,35 @@ public class ClassSaveApi {
 
 	/** Аббревиатура книги-источника, например MM. Пусто — самодельный контент. */
 	private String source;
+
+	public ClassSaveApi(HeroClass heroClass) {
+		this(heroClass, heroClass.getTraits());
+	}
+
+	public ClassSaveApi(HeroClass heroClass, List<HeroClassTrait> traits) {
+		name = heroClass.getName();
+		englishName = heroClass.getEnglishName();
+		accusativeName = heroClass.getAccusativeName();
+		description = heroClass.getDescription();
+		diceHp = heroClass.getDiceHp();
+		armor = heroClass.getArmor();
+		weapon = heroClass.getWeapon();
+		tools = heroClass.getTools();
+		savingThrows = heroClass.getSavingThrows();
+		archetypeName = heroClass.getArchetypeName();
+		equipment = heroClass.getEquipment();
+		spellAbility = heroClass.getSpellAbility();
+		spellcasterType = heroClass.getSpellcasterType();
+		primaryAbilities = heroClass.getPrimaryAbilities();
+		enabledArhitypeLevel = (short) heroClass.getEnabledArhitypeLevel();
+		skillAvailableCount = heroClass.getSkillAvailableCount();
+		availableSkills = heroClass.getAvailableSkills();
+		optionType = heroClass.getOptionType();
+		slotsReset = heroClass.getSlotsReset();
+		sidekick = heroClass.isSidekick();
+		icon = heroClass.getIcon();
+		page = heroClass.getPage();
+		classTraits = traits.stream().map(ClassTraitSaveApi::new).collect(java.util.stream.Collectors.toList());
+		source = heroClass.getBook() == null ? null : heroClass.getBook().getSource();
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/classes/ClassTraitSaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/classes/ClassTraitSaveApi.java
@@ -1,5 +1,7 @@
 package club.dnd5.portal.dto.api.classes;
 
+import club.dnd5.portal.model.classes.HeroClassTrait;
+import club.dnd5.portal.model.classes.archetype.ArchetypeTrait;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -23,4 +25,23 @@ public class ClassTraitSaveApi {
 	private String description;
 	private boolean optional;
 	private String child;
+
+	public ClassTraitSaveApi(HeroClassTrait trait) {
+		id = trait.getId();
+		name = trait.getName();
+		suffix = trait.getSuffix();
+		level = trait.getLevel();
+		description = trait.getDescription();
+		optional = trait.getOptional() != 0;
+		child = trait.getChild();
+	}
+
+	public ClassTraitSaveApi(ArchetypeTrait trait) {
+		id = trait.getId();
+		name = trait.getName();
+		suffix = trait.getSuffix();
+		level = trait.getLevel();
+		description = trait.getDescription();
+		child = trait.getChild();
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/classes/FeatSaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/classes/FeatSaveApi.java
@@ -2,6 +2,7 @@ package club.dnd5.portal.dto.api.classes;
 
 import club.dnd5.portal.model.AbilityType;
 import club.dnd5.portal.model.SkillType;
+import club.dnd5.portal.model.trait.Trait;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -27,4 +28,16 @@ public class FeatSaveApi {
 
 	/** Аббревиатура книги-источника, например MM. Пусто — самодельный контент. */
 	private String source;
+
+	public FeatSaveApi(Trait trait) {
+		name = trait.getName();
+		englishName = trait.getEnglishName();
+		altName = trait.getAltName();
+		level = trait.getLevel();
+		requirement = trait.getRequirement();
+		description = trait.getDescription();
+		abilities = trait.getAbilities();
+		skills = trait.getSkills();
+		source = trait.getBook() == null ? null : trait.getBook().getSource();
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/classes/OptionSaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/classes/OptionSaveApi.java
@@ -1,6 +1,7 @@
 package club.dnd5.portal.dto.api.classes;
 
 import club.dnd5.portal.model.classes.Option.OptionType;
+import club.dnd5.portal.model.classes.Option;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -27,4 +28,15 @@ public class OptionSaveApi {
 
 	/** Аббревиатура книги-источника, например MM. Пусто — самодельный контент. */
 	private String source;
+
+	public OptionSaveApi(Option option) {
+		name = option.getName();
+		englishName = option.getEnglishName();
+		altName = option.getAltName();
+		optionTypes = option.getOptionTypes();
+		prerequisite = option.getPrerequisite();
+		level = option.getLevel();
+		description = option.getDescription();
+		source = option.getBook() == null ? null : option.getBook().getSource();
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/item/ArmorSaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/item/ArmorSaveApi.java
@@ -1,6 +1,7 @@
 package club.dnd5.portal.dto.api.item;
 
 import club.dnd5.portal.model.items.ArmorCategory;
+import club.dnd5.portal.model.items.Armor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -28,4 +29,18 @@ public class ArmorSaveApi {
 
 	/** Аббревиатура книги-источника, например MM. Пусто — самодельный контент. */
 	private String source;
+
+	public ArmorSaveApi(Armor armor) {
+		name = armor.getName();
+		englishName = armor.getEnglishName();
+		altName = armor.getAltName();
+		armorClass = armor.getAC();
+		cost = armor.getCost();
+		weight = armor.getWeight();
+		forceRequirements = armor.getForceRequirements();
+		stealthHindrance = armor.isStelsHindrance();
+		type = armor.getType();
+		description = armor.getDescription();
+		source = armor.getBook() == null ? null : armor.getBook().getSource();
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/item/ItemSaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/item/ItemSaveApi.java
@@ -2,6 +2,7 @@ package club.dnd5.portal.dto.api.item;
 
 import club.dnd5.portal.model.items.Currency;
 import club.dnd5.portal.model.items.EquipmentType;
+import club.dnd5.portal.model.items.Equipment;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -26,4 +27,16 @@ public class ItemSaveApi {
 
 	/** Аббревиатура книги-источника, например MM. Пусто — самодельный контент. */
 	private String source;
+
+	public ItemSaveApi(Equipment item) {
+		name = item.getName();
+		englishName = item.getEnglishName();
+		altName = item.getAltName();
+		cost = item.getCost();
+		currency = item.getCurrency();
+		weight = item.getWeight();
+		description = item.getDescription();
+		categories = item.getTypes() == null ? null : new java.util.ArrayList<>(item.getTypes());
+		source = item.getBook() == null ? null : item.getBook().getSource();
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/item/MagicItemSaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/item/MagicItemSaveApi.java
@@ -2,6 +2,7 @@ package club.dnd5.portal.dto.api.item;
 
 import club.dnd5.portal.model.items.MagicThingType;
 import club.dnd5.portal.model.items.Rarity;
+import club.dnd5.portal.model.items.MagicItem;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -35,4 +36,22 @@ public class MagicItemSaveApi {
 
 	/** Аббревиатура книги-источника, например MM. Пусто — самодельный контент. */
 	private String source;
+
+	public MagicItemSaveApi(MagicItem item) {
+		name = item.getName();
+		englishName = item.getEnglishName();
+		altName = item.getAltName();
+		rarity = item.getRarity();
+		type = item.getType();
+		customization = item.getCustomization();
+		custSpecial = item.getCustSpecial();
+		special = item.getSpecial();
+		description = item.getDescription();
+		consumed = item.isConsumed();
+		charge = item.getCharge();
+		curse = item.getCurse();
+		cost = item.getCost();
+		bonus = item.getBonus();
+		source = item.getBook() == null ? null : item.getBook().getSource();
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/item/WeaponSaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/item/WeaponSaveApi.java
@@ -4,6 +4,7 @@ import club.dnd5.portal.model.DamageType;
 import club.dnd5.portal.model.Dice;
 import club.dnd5.portal.model.items.Currency;
 import club.dnd5.portal.model.items.WeaponType;
+import club.dnd5.portal.model.items.Weapon;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -40,4 +41,26 @@ public class WeaponSaveApi {
 
 	/** Аббревиатура книги-источника, например MM. Пусто — самодельный контент. */
 	private String source;
+
+	public WeaponSaveApi(Weapon weapon) {
+		name = weapon.getName();
+		englishName = weapon.getEnglishName();
+		altName = weapon.getAltName();
+		cost = weapon.getCost();
+		currency = weapon.getCurrency();
+		weight = weapon.getWeight();
+		damageDice = weapon.getDamageDice();
+		twoHandDamageDice = weapon.getTwoHandDamageDice();
+		numberDice = weapon.getNumberDice();
+		damageType = weapon.getDamageType();
+		type = weapon.getType();
+		minDistance = weapon.getMinDistance();
+		maxDistance = weapon.getMaxDistance();
+		properties = weapon.getProperties() == null ? java.util.Collections.emptyList()
+			: weapon.getProperties().stream().map(property -> property.getId()).collect(java.util.stream.Collectors.toList());
+		ammo = weapon.getAmmo();
+		description = weapon.getDescription();
+		special = weapon.getSpecial();
+		source = weapon.getBook() == null ? null : weapon.getBook().getSource();
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/races/RaceAbilitySaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/races/RaceAbilitySaveApi.java
@@ -1,6 +1,7 @@
 package club.dnd5.portal.dto.api.races;
 
 import club.dnd5.portal.model.AbilityType;
+import club.dnd5.portal.model.AbilityBonus;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -15,4 +16,10 @@ public class RaceAbilitySaveApi {
 	@NotNull
 	private AbilityType ability;
 	private Byte bonus;
+
+	public RaceAbilitySaveApi(AbilityBonus abilityBonus) {
+		id = abilityBonus.getId();
+		ability = abilityBonus.getAbility();
+		bonus = abilityBonus.getBonus();
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/races/RaceFeatureSaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/races/RaceFeatureSaveApi.java
@@ -1,5 +1,6 @@
 package club.dnd5.portal.dto.api.races;
 
+import club.dnd5.portal.model.races.Feature;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -18,4 +19,13 @@ public class RaceFeatureSaveApi {
 	private String description;
 	private boolean feature;
 	private Integer replaceFeatureId;
+
+	public RaceFeatureSaveApi(Feature raceFeature) {
+		id = raceFeature.getId();
+		name = raceFeature.getName();
+		englishName = raceFeature.getEnglishName();
+		description = raceFeature.getDescription();
+		feature = raceFeature.isFeature();
+		replaceFeatureId = raceFeature.getReplaceFeatureId();
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/races/RaceSaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/races/RaceSaveApi.java
@@ -2,6 +2,9 @@ package club.dnd5.portal.dto.api.races;
 
 import club.dnd5.portal.model.CreatureSize;
 import club.dnd5.portal.model.CreatureType;
+import club.dnd5.portal.model.races.Race;
+import club.dnd5.portal.model.AbilityBonus;
+import club.dnd5.portal.model.races.Feature;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -47,4 +50,32 @@ public class RaceSaveApi {
 
 	/** Аббревиатура книги-источника, например MM. Пусто — самодельный контент. */
 	private String source;
+
+	public RaceSaveApi(Race race) {
+		this(race, race.getBonuses(), race.getFeatures());
+	}
+
+	public RaceSaveApi(Race race, List<AbilityBonus> raceAbilities, List<Feature> raceFeatures) {
+		name = race.getName();
+		altName = race.getAltName();
+		englishName = race.getEnglishName();
+		minAge = race.getMinAge();
+		maxAge = race.getMaxAge();
+		description = race.getDescription();
+		parentId = race.getParent() == null ? null : race.getParent().getId();
+		size = race.getSize();
+		type = race.getType();
+		darkvision = race.getDarkvision();
+		speed = race.getSpeed();
+		fly = race.getFly();
+		climb = race.getClimb();
+		swim = race.getSwim();
+		origin = race.getOrigin();
+		view = race.isView();
+		icon = race.getIcon();
+		page = race.getPage();
+		abilities = raceAbilities.stream().map(RaceAbilitySaveApi::new).collect(java.util.stream.Collectors.toList());
+		features = raceFeatures.stream().map(RaceFeatureSaveApi::new).collect(java.util.stream.Collectors.toList());
+		source = race.getBook() == null ? null : race.getBook().getSource();
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/api/spell/SpellSaveApi.java
+++ b/src/main/java/club/dnd5/portal/dto/api/spell/SpellSaveApi.java
@@ -2,6 +2,8 @@ package club.dnd5.portal.dto.api.spell;
 
 import club.dnd5.portal.model.TimeUnit;
 import club.dnd5.portal.model.splells.MagicSchool;
+import club.dnd5.portal.model.splells.Spell;
+import club.dnd5.portal.model.splells.TimeCast;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -58,4 +60,29 @@ public class SpellSaveApi {
 
 	/** Аббревиатура книги-источника, например MM. Пусто — самодельный контент. */
 	private String source;
+
+	public SpellSaveApi(Spell spell) {
+		name = spell.getName();
+		englishName = spell.getEnglishName();
+		level = spell.getLevel();
+		school = spell.getSchool();
+		additionalType = spell.getAdditionalType();
+		ritual = spell.getRitual();
+		concentration = spell.getConcentration();
+		verbalComponent = spell.isVerbalComponent();
+		somaticComponent = spell.isSomaticComponent();
+		consumable = spell.getConsumable();
+		materialComponent = spell.getAdditionalMaterialComponent();
+		if (spell.getTimes() != null && !spell.getTimes().isEmpty()) {
+			TimeCast time = spell.getTimes().get(0);
+			timeNumber = time.getNumber();
+			timeUnit = time.getUnit();
+			timeCondition = time.getCondition();
+		}
+		range = spell.getDistance();
+		duration = spell.getDuration();
+		description = spell.getDescription();
+		upper = spell.getUpperLevel();
+		source = spell.getBook() == null ? null : spell.getBook().getSource();
+	}
 }

--- a/src/main/java/club/dnd5/portal/dto/user/DisplayNameDto.java
+++ b/src/main/java/club/dnd5/portal/dto/user/DisplayNameDto.java
@@ -1,0 +1,30 @@
+package club.dnd5.portal.dto.user;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+/**
+ * Отображаемое имя пользователя — тело PATCH и ответ GET. Ограничения совпадают с новым
+ * сайтом (core-app): 2–24 символа, буквы (в т.ч. кириллица), цифры, пробелы, дефис,
+ * подчёркивание. В ответе на GET имя может быть {@code null} — тогда показывается логин.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class DisplayNameDto {
+    @NotBlank(message = "Отображаемое имя обязательно")
+    @Size(min = 2, max = 24, message = "От 2 до 24 символов")
+    @Pattern(
+            regexp = "^[\\w\\p{L}\\s-]+$",
+            message = "Только буквы, цифры, пробелы, дефисы и подчёркивания")
+    private String displayName;
+
+    public DisplayNameDto(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/src/main/java/club/dnd5/portal/model/creature/Creature.java
+++ b/src/main/java/club/dnd5/portal/model/creature/Creature.java
@@ -134,6 +134,7 @@ public class Creature implements FoundryCommon {
 	private List<Language> languages;
 
 	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "creature_id")
 	private List<CreatureFeat> feats;
 
 	@ManyToMany(cascade = CascadeType.ALL)
@@ -269,11 +270,7 @@ public class Creature implements FoundryCommon {
 			.collect(Collectors.toList());
 	}
 
-	public List<Action> getActions(){
- 		return actions;
-	}
-
-	public Byte getSavingThrow(AbilityType abilityType) {
+    public Byte getSavingThrow(AbilityType abilityType) {
 		return savingThrows.stream()
 			.filter(st-> st.getAbility() == abilityType)
 			.map(SavingThrow::getBonus)

--- a/src/main/java/club/dnd5/portal/model/user/User.java
+++ b/src/main/java/club/dnd5/portal/model/user/User.java
@@ -22,6 +22,12 @@ public class User {
 	private String username;
 	private String password;
 	private String email;
+
+	// Отображаемое имя для комментариев (и прочих мест, где логин показывать не хочется).
+	// null — имя не задано, и везде показывается username. Колонку добавляет ddl-auto=update.
+	@Column(name = "display_name", length = 24)
+	private String displayName;
+
 	private LocalDateTime createDate;
 
 	@ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.MERGE)

--- a/src/main/java/club/dnd5/portal/service/CommentsRenameClient.java
+++ b/src/main/java/club/dnd5/portal/service/CommentsRenameClient.java
@@ -1,0 +1,107 @@
+package club.dnd5.portal.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Клиент межсервисной ручки comments-service, массово приводящей имя автора в его
+ * комментариях к отображаемому имени. Дёргается после смены имени в профиле и после
+ * публикации комментария (сервис стамперит логин из токена — этот вызов заменяет его).
+ * <p>
+ * Переименование скоупится платформой этого сайта ({@link #SOURCE_PLATFORM}): {@code authorId}
+ * (клейм {@code sub}) общий у пользователя на всех сайтах через единый auth-service, а имя у
+ * каждого сайта своё — без скоупа вызов переписал бы и комментарии автора на новом сайте.
+ * <p>
+ * Всё best-effort: без межсервисного токена ({@code comments-service.internal-token}) или при
+ * ошибке запроса переименование тихо пропускается — синхронизация имени не должна ронять
+ * пользовательский поток.
+ */
+@Component
+public class CommentsRenameClient {
+    /** Платформа-источник этого сайта в сервисе комментариев (редакция 2014). */
+    private static final String SOURCE_PLATFORM = "SITE_5E14";
+
+    /** Заголовок межсервисной авторизации internal API comments-service. */
+    private static final String SERVICE_TOKEN_HEADER = "X-Service-Token";
+
+    /** Internal-эндпоинт массового переименования автора. */
+    private static final String RENAME_PATH = "/api/v1/internal/comments/rename-by-author";
+
+    private static final int CONNECT_TIMEOUT_MS = 5_000;
+    private static final int READ_TIMEOUT_MS = 15_000;
+
+    private final RestTemplate restTemplate = buildRestTemplate();
+    private final String baseUrl;
+    private final String serviceToken;
+
+    public CommentsRenameClient(
+            @Value("${comments-service.base-url}") String baseUrl,
+            @Value("${comments-service.internal-token:}") String serviceToken) {
+        this.baseUrl = trimTrailingSlash(baseUrl);
+        this.serviceToken = serviceToken;
+    }
+
+    /**
+     * Приводит имя автора в его комментариях этого сайта к переданному имени. Возвращает
+     * {@code true}, если запрос ушёл успешно; {@code false} — если межсервисный токен не задан
+     * или сервис ответил ошибкой (тогда имя обновится при следующей синхронизации).
+     *
+     * @param authorId    UUID автора (клейм {@code sub} токена auth-service)
+     * @param displayName отображаемое имя
+     */
+    public boolean rename(String authorId, String displayName) {
+        if (!StringUtils.hasText(serviceToken) || !StringUtils.hasText(authorId)
+                || !StringUtils.hasText(displayName)) {
+            return false;
+        }
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("authorId", authorId);
+        body.put("sourcePlatform", SOURCE_PLATFORM);
+        body.put("displayName", displayName);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set(SERVICE_TOKEN_HEADER, serviceToken);
+
+        try {
+            restTemplate.exchange(
+                    baseUrl + RENAME_PATH,
+                    HttpMethod.POST,
+                    new HttpEntity<>(body, headers),
+                    Void.class);
+
+            return true;
+        } catch (RuntimeException error) {
+            // Best-effort: имя подхватится при следующем вызове (после публикации/смены имени).
+            return false;
+        }
+    }
+
+    private static RestTemplate buildRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        factory.setReadTimeout(READ_TIMEOUT_MS);
+
+        return new RestTemplate(factory);
+    }
+
+    private static String trimTrailingSlash(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        String trimmed = value.trim();
+        return trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,11 @@ spring.profiles.active=local
 
 auth-service.base-url=https://auth.api.ttg.club
 
+# Сервис комментариев проксируется CommentsProxyController (/api/v1/comments/**).
+# Дев-инстанса у сервиса нет — по умолчанию прод; переопределяется через
+# COMMENTS_SERVICE_URL, если появится отдельный адрес.
+comments-service.base-url=${COMMENTS_SERVICE_URL:https://comments.ttg.club}
+
 online.api.url=${ONLINE_API_URL:}
 online.api.token=${ONLINE_API_TOKEN:}
 online.site-id=${ONLINE_SITE_ID:5e14}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,6 +27,11 @@ auth-service.base-url=https://auth.api.ttg.club
 # COMMENTS_SERVICE_URL, если появится отдельный адрес.
 comments-service.base-url=${COMMENTS_SERVICE_URL:https://comments.ttg.club}
 
+# Межсервисный секрет для internal-ручки переименования автора (X-Service-Token).
+# Тот же INTERNAL_SERVICE_SECRET, что задан в comments-service. Пусто — синхронизация
+# имени в комментариях просто пропускается (best-effort).
+comments-service.internal-token=${COMMENTS_SERVICE_INTERNAL_TOKEN:}
+
 online.api.url=${ONLINE_API_URL:}
 online.api.token=${ONLINE_API_TOKEN:}
 online.site-id=${ONLINE_SITE_ID:5e14}

--- a/src/test/java/club/dnd5/portal/controller/api/item/ItemApiControllerTest.java
+++ b/src/test/java/club/dnd5/portal/controller/api/item/ItemApiControllerTest.java
@@ -7,10 +7,12 @@ import club.dnd5.portal.model.book.TypeBook;
 import club.dnd5.portal.model.items.Currency;
 import club.dnd5.portal.model.items.Equipment;
 import club.dnd5.portal.model.items.EquipmentType;
+import club.dnd5.portal.model.audit.RevisionOperation;
 import club.dnd5.portal.repository.datatable.ItemRepository;
 import club.dnd5.portal.service.AuditService;
 import club.dnd5.portal.service.BookResolver;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,7 +21,9 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ItemApiControllerTest {
@@ -52,12 +56,45 @@ class ItemApiControllerTest {
 		assertThat(detail.getPrice()).isEqualTo("25 мм");
 	}
 
+	@Test
+	void shouldRecordStateBeforeUpdate() {
+		Equipment item = existingItem();
+		item.setName("Old name");
+		item.setEnglishName("Old name");
+		item.setCost(10);
+		item.setCurrency(Currency.GM);
+		AuditService auditService = mock(AuditService.class);
+		ItemApiController controller = controllerFor(item, auditService);
+
+		ItemSaveApi request = request();
+		request.setName("New name");
+		request.setEnglishName("New name");
+		request.setCost(25);
+		request.setCurrency(Currency.MM);
+		request.setCategories(Collections.singletonList(EquipmentType.TOOL));
+
+		controller.updateItem(1, request);
+
+		ArgumentCaptor<ItemSaveApi> snapshot = ArgumentCaptor.forClass(ItemSaveApi.class);
+		verify(auditService).record(eq("ITEM"), eq(1), eq(RevisionOperation.UPDATE), snapshot.capture());
+		assertThat(snapshot.getValue().getName()).isEqualTo("Old name");
+		assertThat(snapshot.getValue().getCost()).isEqualTo(10);
+		assertThat(snapshot.getValue().getCurrency()).isEqualTo(Currency.GM);
+		assertThat(snapshot.getValue().getCategories())
+			.containsExactly(EquipmentType.ADVENTURING_GEAR, EquipmentType.CONTAINER);
+		assertThat(item.getName()).isEqualTo("New name");
+	}
+
 	private ItemApiController controllerFor(Equipment item) {
+		return controllerFor(item, mock(AuditService.class));
+	}
+
+	private ItemApiController controllerFor(Equipment item, AuditService auditService) {
 		ItemRepository itemRepository = mock(ItemRepository.class);
 		when(itemRepository.findById(1)).thenReturn(Optional.of(item));
 		when(itemRepository.findByEnglishName(any())).thenReturn(Optional.empty());
 		when(itemRepository.saveAndFlush(any(Equipment.class))).thenAnswer(invocation -> invocation.getArgument(0));
-		return new ItemApiController(itemRepository, mock(BookResolver.class), mock(AuditService.class));
+		return new ItemApiController(itemRepository, mock(BookResolver.class), auditService);
 	}
 
 	private Equipment existingItem() {


### PR DESCRIPTION
Старый сайт — статический SPA, который отдаёт этот же монолит, поэтому запрос фронта на относительный /api/v1/comments/** приходил в Spring и упирался в отсутствующий контроллер (404). В отличие от нового сайта, где ту же роль играет Nitro-сервер Nuxt, у старого своего сервера нет — форвардить на comments.ttg.club должен монолит.

CommentsProxyController форвардит любой метод как есть. Токен берётся как в AuthServiceAuthenticationFilter (заголовок, затем кука dnd5_user_token) и уходит заголовком Authorization: Bearer — сервис куку не понимает, а прод-фронт шлёт токен именно кукой. Ошибки сервиса (ProblemDetail, 429 с Retry-After, 409) доходят до фронта как есть: обработчик ошибок RestTemplate отключён. Таймауты 5с/15с, 502 при недоступности сервиса.

permitAll на /api/v1/comments/** нужен ради DELETE (остальные методы уже открыты) — авторизацию целиком проверяет сам сервис.

Адрес сервиса — comments-service.base-url (COMMENTS_SERVICE_URL, по умолчанию прод: дев-инстанса у сервиса нет).