### PR TITLE
fix(авторизация): устойчивость SSO-прокси, чтобы сессия не отваливалась

### DIFF
--- a/src/main/java/club/dnd5/portal/config/WebSecurityConfig.java
+++ b/src/main/java/club/dnd5/portal/config/WebSecurityConfig.java
@@ -5,6 +5,7 @@ import club.dnd5.portal.security.AuthServiceAuthenticationFilter;
 import club.dnd5.portal.security.ExternalAuthClient;
 import club.dnd5.portal.security.ExternalAuthUserSynchronizer;
 import club.dnd5.portal.security.JwtAuthenticationEntryPoint;
+import club.dnd5.portal.security.TokenAuthenticationCache;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
@@ -42,9 +43,25 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter implements W
 	@Value("${allowed-origin-patterns}")
 	private String[] originPatterns;
 
+	// Как долго провалидированный токен считается свежим и не перепроверяется в SSO.
+	@Value("${auth-service.cache.fresh-ttl-ms:60000}")
+	private long tokenCacheFreshTtlMs;
+
+	// До какого возраста провалидированный токен можно использовать как fallback при недоступности SSO.
+	@Value("${auth-service.cache.stale-ttl-ms:600000}")
+	private long tokenCacheStaleTtlMs;
+
+	@Value("${auth-service.cache.max-entries:20000}")
+	private int tokenCacheMaxEntries;
+
+    @Bean
+    public TokenAuthenticationCache tokenAuthenticationCache() {
+        return new TokenAuthenticationCache(tokenCacheFreshTtlMs, tokenCacheStaleTtlMs, tokenCacheMaxEntries);
+    }
+
     @Bean
     public AuthServiceAuthenticationFilter authServiceAuthenticationFilter(){
-        return new AuthServiceAuthenticationFilter(externalAuthClient, userSynchronizer);
+        return new AuthServiceAuthenticationFilter(externalAuthClient, userSynchronizer, tokenAuthenticationCache());
 	}
 
 	@Override

--- a/src/main/java/club/dnd5/portal/controller/api/AuthApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/AuthApiController.java
@@ -123,7 +123,10 @@ public class AuthApiController {
 		ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
 				.httpOnly(true)
 				.secure(secure)
-				.sameSite("Strict")
+				// Lax, а не Strict: при переходе на сайт по внешней ссылке Strict не отдаёт куку
+				// на первую навигацию — пользователь видит «разлогин»-мигание. Lax это устраняет,
+				// оставаясь защитой от CSRF (кука не уходит на кросс-сайтовых POST/подзапросах).
+				.sameSite("Lax")
 				.path(path);
 		if (maxAge >= 0) {
 			builder.maxAge(maxAge);

--- a/src/main/java/club/dnd5/portal/controller/api/user/UserApiController.java
+++ b/src/main/java/club/dnd5/portal/controller/api/user/UserApiController.java
@@ -32,7 +32,10 @@ public class UserApiController {
 				return ResponseEntity.ok(true);
 			}
 		}
-		return ResponseEntity.ok(false);
+		// 401 (а не 200 false), чтобы фронтовый refresh-интерсептор мог прозрачно продлить
+		// протухший access-токен. Иначе status-проверки молча разлогинивали пользователя,
+		// у которого ещё жив refresh-токен.
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 	}
 
 	@GetMapping("/info")

--- a/src/main/java/club/dnd5/portal/security/AuthServiceAuthenticationFilter.java
+++ b/src/main/java/club/dnd5/portal/security/AuthServiceAuthenticationFilter.java
@@ -1,6 +1,6 @@
 package club.dnd5.portal.security;
 
-import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
@@ -8,6 +8,7 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -15,13 +16,24 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 import java.util.List;
 
-@RequiredArgsConstructor
 public class AuthServiceAuthenticationFilter extends OncePerRequestFilter {
     private final ExternalAuthClient externalAuthClient;
     private final ExternalAuthUserSynchronizer userSynchronizer;
+    private final TokenAuthenticationCache cache;
+
+    public AuthServiceAuthenticationFilter(ExternalAuthClient externalAuthClient,
+                                           ExternalAuthUserSynchronizer userSynchronizer,
+                                           TokenAuthenticationCache cache) {
+        this.externalAuthClient = externalAuthClient;
+        this.userSynchronizer = userSynchronizer;
+        this.cache = cache;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -29,19 +41,82 @@ public class AuthServiceAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
         String token = getTokenFromRequest(request);
         if (StringUtils.hasText(token) && !isAuthenticated()) {
-            try {
-                ExternalAuthUser user = externalAuthClient.me(token);
-                userSynchronizer.sync(user);
-
-                UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-                        principalName(user), null, getAuthorities(user.getRoles()));
-                authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
-            } catch (RuntimeException exception) {
-                SecurityContextHolder.clearContext();
+            ExternalAuthUser user = resolveUser(token);
+            if (user != null) {
+                authenticate(request, user);
             }
         }
         filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Возвращает пользователя для токена, либо {@code null}, если авторизацию нужно сбросить.
+     *
+     * <p>Ключевое отличие от прежней логики: транзиентный сбой SSO (таймаут, 5xx, обрыв,
+     * 429) больше не приравнивается к невалидному токену. Только явный отказ авторизации
+     * (401/403) сбрасывает сессию; при недоступности SSO используется недавно
+     * провалидированный (stale) результат, чтобы пользователя не разлогинивало на ровном месте.
+     */
+    private ExternalAuthUser resolveUser(String token) {
+        String key = cacheKey(token);
+        TokenAuthenticationCache.Entry cached = cache.get(key);
+        if (cached != null && cached.isFresh()) {
+            return cached.getUser();
+        }
+
+        try {
+            ExternalAuthUser user = externalAuthClient.me(token);
+            userSynchronizer.sync(user);
+            cache.put(key, user);
+            return user;
+        } catch (HttpStatusCodeException exception) {
+            if (isAuthRejection(exception.getStatusCode())) {
+                // Токен действительно невалиден/протух — сбрасываем.
+                cache.evict(key);
+                SecurityContextHolder.clearContext();
+                return null;
+            }
+            // 5xx, 429 и прочее — транзиентно: пробуем пережить на stale-копии.
+            return fallbackOrClear(cached);
+        } catch (RuntimeException exception) {
+            // ResourceAccessException (таймаут/обрыв соединения) и другие сетевые сбои.
+            return fallbackOrClear(cached);
+        }
+    }
+
+    private ExternalAuthUser fallbackOrClear(TokenAuthenticationCache.Entry cached) {
+        if (cached != null && cached.isUsableStale(System.currentTimeMillis())) {
+            return cached.getUser();
+        }
+        SecurityContextHolder.clearContext();
+        return null;
+    }
+
+    private boolean isAuthRejection(HttpStatus status) {
+        return status == HttpStatus.UNAUTHORIZED || status == HttpStatus.FORBIDDEN;
+    }
+
+    private void authenticate(HttpServletRequest request, ExternalAuthUser user) {
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                principalName(user), null, getAuthorities(user.getRoles()));
+        authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    }
+
+    private String cacheKey(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            StringBuilder builder = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                builder.append(Character.forDigit((b >> 4) & 0xF, 16));
+                builder.append(Character.forDigit(b & 0xF, 16));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException exception) {
+            // SHA-256 гарантированно доступен на любой JVM; fallback на сам токен.
+            return token;
+        }
     }
 
     private String getTokenFromRequest(HttpServletRequest request) {

--- a/src/main/java/club/dnd5/portal/security/ExternalAuthClient.java
+++ b/src/main/java/club/dnd5/portal/security/ExternalAuthClient.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
@@ -27,15 +28,25 @@ public class ExternalAuthClient {
     private static final String FRONTEND_ORIGIN_HEADER = "X-Frontend-Origin";
     private static final Pattern TOKEN_PATTERN = Pattern.compile("^[A-Za-z0-9._-]{1,2048}$");
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
     private final String baseUrl;
     private final String frontendOrigin;
 
     public ExternalAuthClient(
             @Value("${auth-service.base-url}") String baseUrl,
-            @Value("${app.url:}") String frontendOrigin) {
+            @Value("${app.url:}") String frontendOrigin,
+            @Value("${auth-service.connect-timeout-ms:2000}") int connectTimeoutMs,
+            @Value("${auth-service.read-timeout-ms:4000}") int readTimeoutMs) {
         this.baseUrl = trimTrailingSlash(baseUrl);
         this.frontendOrigin = trimTrailingSlash(frontendOrigin);
+        this.restTemplate = buildRestTemplate(connectTimeoutMs, readTimeoutMs);
+    }
+
+    private static RestTemplate buildRestTemplate(int connectTimeoutMs, int readTimeoutMs) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(connectTimeoutMs);
+        factory.setReadTimeout(readTimeoutMs);
+        return new RestTemplate(factory);
     }
 
     public JWTAuthResponse login(LoginDto loginDto) {

--- a/src/main/java/club/dnd5/portal/security/TokenAuthenticationCache.java
+++ b/src/main/java/club/dnd5/portal/security/TokenAuthenticationCache.java
@@ -1,0 +1,94 @@
+package club.dnd5.portal.security;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Короткоживущий кеш результатов валидации токена во внешнем SSO.
+ *
+ * <p>Решает две задачи, из-за которых «авторизация отваливалась»:
+ * <ul>
+ *     <li>снимает нагрузку с {@code /api/auth/me} — валидный токен проверяется не на
+ *         каждый запрос, а не чаще раза в {@code freshTtlMs};</li>
+ *     <li>даёт «протухшую» копию ({@code staleUntil}) для fallback, когда SSO временно
+ *         недоступен (таймаут/5xx/обрыв), чтобы транзиентный сбой не логаутил пользователя.</li>
+ * </ul>
+ *
+ * <p>Ключ — хеш токена (см. {@link AuthServiceAuthenticationFilter}), сырые JWT в долгоживущей
+ * структуре не хранятся.
+ */
+public class TokenAuthenticationCache {
+    private final Map<String, Entry> cache = new ConcurrentHashMap<>();
+    private final long freshTtlMs;
+    private final long staleTtlMs;
+    private final int maxEntries;
+
+    public TokenAuthenticationCache(long freshTtlMs, long staleTtlMs, int maxEntries) {
+        this.freshTtlMs = freshTtlMs;
+        this.staleTtlMs = staleTtlMs;
+        this.maxEntries = maxEntries;
+    }
+
+    /** Возвращает запись, если она ещё пригодна хотя бы как stale, иначе {@code null} (с очисткой). */
+    public Entry get(String key) {
+        Entry entry = cache.get(key);
+        if (entry == null) {
+            return null;
+        }
+        if (entry.isExpired(now())) {
+            cache.remove(key, entry);
+            return null;
+        }
+        return entry;
+    }
+
+    public void put(String key, ExternalAuthUser user) {
+        long now = now();
+        if (cache.size() >= maxEntries) {
+            evictExpired(now);
+        }
+        cache.put(key, new Entry(user, now + freshTtlMs, now + staleTtlMs));
+    }
+
+    public void evict(String key) {
+        cache.remove(key);
+    }
+
+    private void evictExpired(long now) {
+        cache.values().removeIf(entry -> entry.isExpired(now));
+    }
+
+    private long now() {
+        return System.currentTimeMillis();
+    }
+
+    public static final class Entry {
+        private final ExternalAuthUser user;
+        private final long freshUntil;
+        private final long staleUntil;
+
+        Entry(ExternalAuthUser user, long freshUntil, long staleUntil) {
+            this.user = user;
+            this.freshUntil = freshUntil;
+            this.staleUntil = staleUntil;
+        }
+
+        public ExternalAuthUser getUser() {
+            return user;
+        }
+
+        /** Свежая запись — можно авторизовать без обращения к SSO. */
+        public boolean isFresh() {
+            return System.currentTimeMillis() < freshUntil;
+        }
+
+        /** Пригодна как fallback при недоступности SSO. */
+        public boolean isUsableStale(long now) {
+            return now < staleUntil;
+        }
+
+        boolean isExpired(long now) {
+            return now >= staleUntil;
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,17 @@ spring.profiles.active=local
 
 auth-service.base-url=https://auth.api.ttg.club
 
+# Таймауты обращения к SSO (/api/auth/me и т.д.). Без них зависший SSO копит потоки Tomcat.
+auth-service.connect-timeout-ms=${AUTH_SERVICE_CONNECT_TIMEOUT_MS:2000}
+auth-service.read-timeout-ms=${AUTH_SERVICE_READ_TIMEOUT_MS:4000}
+
+# Кеш валидации токена. fresh-ttl — как долго токен не перепроверяется в SSO (снижает нагрузку);
+# stale-ttl — до какого возраста провалидированный токен используется как fallback при
+# недоступности SSO, чтобы транзиентный сбой (таймаут/5xx/429) не разлогинивал пользователя.
+auth-service.cache.fresh-ttl-ms=${AUTH_SERVICE_CACHE_FRESH_TTL_MS:60000}
+auth-service.cache.stale-ttl-ms=${AUTH_SERVICE_CACHE_STALE_TTL_MS:600000}
+auth-service.cache.max-entries=${AUTH_SERVICE_CACHE_MAX_ENTRIES:20000}
+
 # Сервис комментариев проксируется CommentsProxyController (/api/v1/comments/**).
 # Дев-инстанса у сервиса нет — по умолчанию прод; переопределяется через
 # COMMENTS_SERVICE_URL, если появится отдельный адрес.

--- a/src/test/java/club/dnd5/portal/security/AuthServiceAuthenticationFilterTest.java
+++ b/src/test/java/club/dnd5/portal/security/AuthServiceAuthenticationFilterTest.java
@@ -1,0 +1,134 @@
+package club.dnd5.portal.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+class AuthServiceAuthenticationFilterTest {
+    private static final String TOKEN = "header.payload.signature";
+
+    private ExternalAuthClient authClient;
+    private ExternalAuthUserSynchronizer synchronizer;
+
+    @BeforeEach
+    void setUp() {
+        authClient = mock(ExternalAuthClient.class);
+        synchronizer = mock(ExternalAuthUserSynchronizer.class);
+        doNothing().when(synchronizer).sync(any());
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void authenticatesOnSuccessfulValidation() throws Exception {
+        when(authClient.me(TOKEN)).thenReturn(user());
+
+        assertEquals("user@ttg.club", runFilter(filter(60_000, 600_000)).getName());
+    }
+
+    @Test
+    void clearsAuthenticationOnUnauthorized() throws Exception {
+        when(authClient.me(TOKEN)).thenThrow(HttpClientErrorException.create(
+                UNAUTHORIZED, "Unauthorized", null, null, null));
+
+        assertNull(runFilter(filter(60_000, 600_000)));
+    }
+
+    @Test
+    void keepsUserOnTransientServerErrorWhenPreviouslyValidated() throws Exception {
+        // freshTtl=0 => запись сразу перестаёт быть свежей, но остаётся пригодной как stale.
+        AuthServiceAuthenticationFilter filter = filter(0, 600_000);
+        when(authClient.me(TOKEN)).thenReturn(user());
+        runFilter(filter); // первый запрос кладёт валидацию в кеш
+
+        when(authClient.me(TOKEN)).thenThrow(HttpServerErrorException.create(
+                INTERNAL_SERVER_ERROR, "Boom", null, null, null));
+
+        // SSO отдаёт 5xx — но благодаря stale-кешу пользователь не разлогинивается.
+        assertEquals("user@ttg.club", runFilter(filter).getName());
+    }
+
+    @Test
+    void keepsUserOnNetworkTimeoutWhenPreviouslyValidated() throws Exception {
+        AuthServiceAuthenticationFilter filter = filter(0, 600_000);
+        when(authClient.me(TOKEN)).thenReturn(user());
+        runFilter(filter);
+
+        when(authClient.me(TOKEN)).thenThrow(new ResourceAccessException("timeout"));
+
+        assertEquals("user@ttg.club", runFilter(filter).getName());
+    }
+
+    @Test
+    void clearsAuthenticationOnTransientErrorWithoutPriorValidation() throws Exception {
+        when(authClient.me(TOKEN)).thenThrow(new ResourceAccessException("timeout"));
+
+        assertNull(runFilter(filter(60_000, 600_000)));
+    }
+
+    @Test
+    void expiredStaleCacheNoLongerRescuesUser() throws Exception {
+        // staleTtl=0 => запись мгновенно протухает целиком, fallback невозможен.
+        AuthServiceAuthenticationFilter filter = filter(0, 0);
+        when(authClient.me(TOKEN)).thenReturn(user());
+        runFilter(filter);
+
+        when(authClient.me(TOKEN)).thenThrow(new ResourceAccessException("timeout"));
+
+        assertNull(runFilter(filter));
+    }
+
+    @Test
+    void doesNotRevalidateFreshToken() throws Exception {
+        AuthServiceAuthenticationFilter filter = filter(60_000, 600_000);
+        when(authClient.me(TOKEN)).thenReturn(user());
+
+        runFilter(filter);
+        runFilter(filter);
+
+        // Второй запрос попал в свежий кеш — повторного обращения к SSO нет.
+        verify(authClient, times(1)).me(anyString());
+    }
+
+    private AuthServiceAuthenticationFilter filter(long freshTtlMs, long staleTtlMs) {
+        return new AuthServiceAuthenticationFilter(
+                authClient, synchronizer, new TokenAuthenticationCache(freshTtlMs, staleTtlMs, 1000));
+    }
+
+    private Authentication runFilter(AuthServiceAuthenticationFilter filter) throws Exception {
+        SecurityContextHolder.clearContext();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/user/profile");
+        request.addHeader("Authorization", "Bearer " + TOKEN);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
+    private ExternalAuthUser user() {
+        ExternalAuthUser user = new ExternalAuthUser();
+        user.setEmail("user@ttg.club");
+        user.setUsername("user");
+        user.setEnabled(true);
+        user.setRoles(Collections.singletonList("USER"));
+        return user;
+    }
+}


### PR DESCRIPTION
## Проблема
Авторизация часто отваливалась: бэкенд-прокси валидирует токен в SSO на каждый запрос и разлогинивал при любом сбое SSO.

## Что сделано
- Фильтр не разлогинивает на транзиентных сбоях SSO (таймаут/5xx/429) — только на 401/403
- Кеш валидации токена с fallback на stale-копию
- Таймауты connect/read у ExternalAuthClient
- `/user/status` для анонима отдаёт 401 вместо `200 false`
- Cookie `SameSite=Strict -> Lax`

Тесты: `AuthServiceAuthenticationFilterTest` (7 кейсов).